### PR TITLE
make package manifests compatible with swift compilers 4.0 and 4.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,5 +21,6 @@ let package = Package(
                 "StringScanner"
             ]
         )
-    ]
+    ],
+    swiftLanguageVersions: [.v4, .v4_2, .v5]
 )

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:4.0
+import PackageDescription
+
+let package = Package(
+    name: "StringScanner",
+    products: [
+        .library(
+            name: "StringScanner",
+            targets: ["StringScanner"]),
+    ],
+    dependencies:[
+    ],
+    targets: [
+        .target(
+            name: "StringScanner",
+            dependencies: []),
+
+        .testTarget(
+            name: "StringScannerTests",
+            dependencies: [
+                "StringScanner"
+            ]
+        )
+    ],
+    swiftLanguageVersions: [4, 5]
+)


### PR DESCRIPTION
The package compiles and tests successfully on 4.0 and 4.2, so they shouldn't be excluded.